### PR TITLE
Update Badge colors to align with Banner tokens 

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -5,12 +5,12 @@ import { Body } from '../typography'
 const Container = styled.div(
   ({ theme: { color, borderRadius } }) => css`
     padding: 3px 8px;
-    background: ${color.badgeBackground};
+    background: ${color.bannerBackground};
     border-radius: ${borderRadius.xs};
     display: inline-block;
     text-transform: capitalize;
     span {
-      color: ${color.badgeText};
+      color: ${color.bannerText};
     }
   `
 )


### PR DESCRIPTION
This PR updates the Badge component to use the same color tokens as Banner for consistency across the app. Previously, Badge defined its own shades, which caused mismatches (e.g. success green, warning yellow).

Changes:
- Swapped in the Banner color token

Fixes #36